### PR TITLE
Fix parsing of beginning-of-line Coq comments

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ def check_coq(coq: str) -> Tuple[str, bool]:
         if line == "":
             continue
         # If the line starts with a coq comment,  skip it
-        if line[0] == "(":
+        if line.strip()[:2] == "(*":
             continue
 
         # Execute the line


### PR DESCRIPTION
This way we don't skip lines like `(idtac + symmetry); reflexivity.`

Why do you want to be skipping comment lines at all, though?

(Also, if you want to fully handle Coq comments, you might want to copy https://github.com/JasonGross/coq-tools/blob/master/strip_comments.py)